### PR TITLE
Ruby 3.x compatibility: update gemspec and replace deprecated APIs

### DIFF
--- a/app/controllers/workarea/admin/catalog_product_swatches_controller.rb
+++ b/app/controllers/workarea/admin/catalog_product_swatches_controller.rb
@@ -21,7 +21,7 @@ module Workarea
       def update
         @swatch = @product.swatches.find(params[:id])
 
-        if @swatch.update_attributes(params[:swatch])
+        if @swatch.update(params[:swatch])
           flash[:success] = t('workarea.admin.catalog_product_swatches.flash_messages.saved')
           redirect_to catalog_product_swatches_path(@product)
         else

--- a/app/controllers/workarea/admin/catalog_swatches_controller.rb
+++ b/app/controllers/workarea/admin/catalog_swatches_controller.rb
@@ -22,7 +22,7 @@ module Workarea
       def update
         @swatch = Catalog::Swatch.find(params[:id])
 
-        if @swatch.update_attributes(params[:swatch])
+        if @swatch.update(params[:swatch])
           flash[:success] = t('workarea.admin.catalog_swatches.flash_messages.saved')
           redirect_to catalog_swatches_path
         else

--- a/app/seeds/workarea/swatches_seeds.rb
+++ b/app/seeds/workarea/swatches_seeds.rb
@@ -31,7 +31,7 @@ module Workarea
         Catalog::Swatch.create!(name: name.to_s.titleize, hex: hex)
       end
 
-      Search::Settings.current.update_attributes!(swatch_facets: ['Color'])
+      Search::Settings.current.update!(swatch_facets: ['Color'])
     end
   end
 end

--- a/test/integration/workarea/storefront/swatches_integration_test.rb
+++ b/test/integration/workarea/storefront/swatches_integration_test.rb
@@ -24,7 +24,7 @@ module Workarea
         create_swatch(name: 'Blue', hex: '0000ff')
         create_swatch(name: 'Green', image: product_image_file)
 
-        Search::Settings.current.update_attributes!(swatch_facets: ['Color'])
+        Search::Settings.current.update!(swatch_facets: ['Color'])
       end
 
       def test_showing_swatch_filters_on_search

--- a/workarea-swatches.gemspec
+++ b/workarea-swatches.gemspec
@@ -17,5 +17,7 @@ Gem::Specification.new do |s|
 
   s.license = 'Business Software License'
 
+  s.required_ruby_version = ['>= 2.7', '< 3.5']
+
   s.add_dependency 'workarea', '~> 3.x', '>= 3.5.x'
 end


### PR DESCRIPTION
## Summary

Modernizes the plugin for Ruby 3.2+ compatibility.

### Changes
- Set `required_ruby_version` to `['>= 2.7', '< 3.5']` in gemspec
- Replace `update_attributes`/`update_attributes!` with `update`/`update!` (deprecated/removed in Rails 6.1+)

### Files Changed
- `workarea-swatches.gemspec`
- `app/seeds/workarea/swatches_seeds.rb`
- `app/controllers/workarea/admin/catalog_product_swatches_controller.rb`
- `app/controllers/workarea/admin/catalog_swatches_controller.rb`
- `test/integration/workarea/storefront/swatches_integration_test.rb`

### Testing
- Verified no remaining `update_attributes` calls
- Backward compatible with Ruby 2.7+

Client impact: None — backward compatible

Closes workarea-commerce/workarea#677